### PR TITLE
Add dragavei

### DIFF
--- a/oltenisme.md
+++ b/oltenisme.md
@@ -24,3 +24,4 @@
 * a sta ciuci
 * maclavais / maglavais
 * câță
+* dragavei


### PR DESCRIPTION
https://dexonline.ro/definitie/dragavei

E cunoscută drept `ștevie`... dar noi oltenii am vrut să fim mai speciali.
